### PR TITLE
Fix clang-tidy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ build
 *.tar.gz
 *.debhelper.log
 *.debhelper
+*.buildinfo
 debian/*.substvars
 wb-homa-adc/debian/wb-homa-adc/
 .d
@@ -17,6 +18,7 @@ debian/tmp
 debian/files
 debhelper-build-stamp
 .clang-format
+compile_commands.json
 
 ### Visual Studio Code ###
 .vscode

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-adc (2.6.5) stable; urgency=medium
+
+  * Fix clang-tidy, no functional changes
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Tue, 30 Jan 2024 10:30:00 +0400
+
 wb-mqtt-adc (2.6.4) stable; urgency=medium
 
   * add arm64 build, no functional changes

--- a/debian/control
+++ b/debian/control
@@ -4,8 +4,6 @@ Section: misc
 Priority: optional
 Standards-Version: 3.9.2
 Build-Depends: debhelper (>= 10),
-               libmosquitto-dev,
-               libmosquittopp-dev,
                libwbmqtt1-4-dev,
                pkg-config,
                libwbmqtt1-4-test-utils,

--- a/src/moving_average.cpp
+++ b/src/moving_average.cpp
@@ -1,6 +1,6 @@
 #include "moving_average.h"
 
-#include <math.h>
+#include <cmath>
 #include <stdexcept>
 
 TMovingAverageCalculator::TMovingAverageCalculator(size_t windowSize)


### PR DESCRIPTION
```sh
$ wbdev compiledb ./clang-tidy-subdirs.sh src test
...
/home/sikmir/wbdev/go/src/github.com/contactless/wb-mqtt-adc/src/moving_average.cpp:29:12: error: no member named 'round' in namespace 'std'; did you mean simply 'round'? [clang-diagnostic-error]
    return std::round(Sum / (double)LastValues.size());
           ^~~~~~~~~~
           round
/usr/include/x86_64-linux-gnu/bits/mathcalls.h:298:14: note: 'round' declared here
__MATHCALLX (round,, (_Mdouble_ __x), (__const__));
             ^
```