### PR TITLE
Add coverage report generation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,4 +2,4 @@ buildDebSbuild defaultTargets: 'bullseye-armhf bullseye-arm64',
                defaultRunLintian: true,
                defaultStyleCheckDirs: 'src test',
                defaultRunCoverage: false,
-               defaultCoverageMin: '75'
+               defaultCoverageMin: '70'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,5 @@
 buildDebSbuild defaultTargets: 'bullseye-armhf bullseye-arm64',
                defaultRunLintian: true,
-               defaultStyleCheckDirs: 'src test'
+               defaultStyleCheckDirs: 'src test',
+               defaultRunCoverage: false,
+               defaultCoverageMin: '75'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,4 +2,4 @@ buildDebSbuild defaultTargets: 'bullseye-armhf bullseye-arm64',
                defaultRunLintian: true,
                defaultStyleCheckDirs: 'src test',
                defaultRunCoverage: false,
-               defaultCoverageMin: '70'
+               defaultCoverageMin: '57'

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ PREFIX = /usr
 
 ADC_BIN = wb-mqtt-adc
 SRC_DIR = src
-ADC_SOURCES := $(shell find $(SRC_DIR) -name *.cpp -and -not -name main.cpp)
+ADC_SOURCES := $(shell find $(SRC_DIR) -name "*.cpp" -and -not -name main.cpp)
 ADC_OBJECTS := $(ADC_SOURCES:%=$(BUILD_DIR)/%.o)
 
 CXXFLAGS = -Wall -std=c++17 -I$(SRC_DIR)
@@ -28,17 +28,25 @@ LDFLAGS = -lwbmqtt1 -lpthread
 ifeq ($(DEBUG),)
 	CXXFLAGS += -O2
 else
-	CXXFLAGS += -g -O0 -fprofile-arcs -ftest-coverage
-	LDFLAGS += -lgcov
+	CXXFLAGS += -g -O0 --coverage
+	LDFLAGS += --coverage
 endif
 
 TEST_DIR = test
-ADC_TEST_SOURCES := $(shell find $(TEST_DIR) -name *.cpp)
+ADC_TEST_SOURCES := $(shell find $(TEST_DIR) -name "*.cpp")
 ADC_TEST_OBJECTS=$(ADC_TEST_SOURCES:%=$(BUILD_DIR)/%.o)
 TEST_BIN = wb-mqtt-adc-test
 TEST_LDFLAGS = -lgtest
 
 export TEST_DIR_ABS = $(CURDIR)/$(TEST_DIR)
+
+VALGRIND_FLAGS = --error-exitcode=180 -q
+
+COV_REPORT ?= $(BUILD_DIR)/cov.html
+GCOVR_FLAGS := --html $(COV_REPORT)
+ifneq ($(COV_FAIL_UNDER),)
+	GCOVR_FLAGS += --fail-under-line $(COV_FAIL_UNDER)
+endif
 
 all: $(BUILD_DIR)/$(ADC_BIN)
 
@@ -56,7 +64,7 @@ $(BUILD_DIR)/$(TEST_DIR)/$(TEST_BIN): $(ADC_OBJECTS) $(ADC_TEST_OBJECTS)
 test: $(BUILD_DIR)/$(TEST_DIR)/$(TEST_BIN)
 	rm -f $(TEST_DIR)/*.dat.out
 	if [ "$(shell arch)" != "armv7l" ] && [ "$(CROSS_COMPILE)" = "" ] || [ "$(CROSS_COMPILE)" = "x86_64-linux-gnu-" ]; then \
-		valgrind --error-exitcode=180 -q $(BUILD_DIR)/$(TEST_DIR)/$(TEST_BIN) $(TEST_ARGS) || \
+		valgrind $(VALGRIND_FLAGS) $(BUILD_DIR)/$(TEST_DIR)/$(TEST_BIN) $(TEST_ARGS) || \
 		if [ $$? = 180 ]; then \
 			echo "*** VALGRIND DETECTED ERRORS ***" 1>& 2; \
 			exit 1; \
@@ -64,11 +72,8 @@ test: $(BUILD_DIR)/$(TEST_DIR)/$(TEST_BIN)
     else \
         $(BUILD_DIR)/$(TEST_DIR)/$(TEST_BIN) $(TEST_ARGS) || { $(TEST_DIR)/abt.sh show; exit 1; } \
 	fi
-
-lcov: test
-ifeq ($(DEBUG), 1)
-	geninfo --no-external -b . -o $(BUILD_DIR)/coverage.info $(BUILD_DIR)/src
-	genhtml $(BUILD_DIR)/coverage.info -o $(BUILD_DIR)/cov_html
+ifneq ($(DEBUG),)
+	gcovr $(GCOVR_FLAGS) $(BUILD_DIR)/$(SRC_DIR) $(BUILD_DIR)/$(TEST_DIR)
 endif
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -69,8 +69,8 @@ test: $(BUILD_DIR)/$(TEST_DIR)/$(TEST_BIN)
 			echo "*** VALGRIND DETECTED ERRORS ***" 1>& 2; \
 			exit 1; \
 		else $(TEST_DIR)/abt.sh show; exit 1; fi; \
-    else \
-        $(BUILD_DIR)/$(TEST_DIR)/$(TEST_BIN) $(TEST_ARGS) || { $(TEST_DIR)/abt.sh show; exit 1; } \
+	else \
+		$(BUILD_DIR)/$(TEST_DIR)/$(TEST_BIN) $(TEST_ARGS) || { $(TEST_DIR)/abt.sh show; exit 1; } \
 	fi
 ifneq ($(DEBUG),)
 	gcovr $(GCOVR_FLAGS) $(BUILD_DIR)/$(SRC_DIR) $(BUILD_DIR)/$(TEST_DIR)

--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,8 @@ export TEST_DIR_ABS = $(CURDIR)/$(TEST_DIR)
 
 VALGRIND_FLAGS = --error-exitcode=180 -q
 
-COV_REPORT ?= $(BUILD_DIR)/cov.html
-GCOVR_FLAGS := -s --html $(COV_REPORT)
+COV_REPORT ?= $(BUILD_DIR)/cov
+GCOVR_FLAGS := -s --html $(COV_REPORT).html -x $(COV_REPORT).xml
 ifneq ($(COV_FAIL_UNDER),)
 	GCOVR_FLAGS += --fail-under-line $(COV_FAIL_UNDER)
 endif

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ export TEST_DIR_ABS = $(CURDIR)/$(TEST_DIR)
 VALGRIND_FLAGS = --error-exitcode=180 -q
 
 COV_REPORT ?= $(BUILD_DIR)/cov.html
-GCOVR_FLAGS := --html $(COV_REPORT)
+GCOVR_FLAGS := -s --html $(COV_REPORT)
 ifneq ($(COV_FAIL_UNDER),)
 	GCOVR_FLAGS += --fail-under-line $(COV_FAIL_UNDER)
 endif

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-adc (2.6.7) stable; urgency=medium
+
+  * Add coverage report generation, no functional changes
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Thu, 26 Sep 2024 20:10:00 +0400
+
 wb-mqtt-adc (2.6.6) stable; urgency=medium
 
   * Add dependency from libwbmqtt1-5. No functional changes

--- a/debian/control
+++ b/debian/control
@@ -4,10 +4,11 @@ Section: misc
 Priority: optional
 Standards-Version: 3.9.2
 Build-Depends: debhelper (>= 10),
+               gcovr:all,
+               libgtest-dev,
                libwbmqtt1-5-dev,
-               pkg-config,
                libwbmqtt1-5-test-utils,
-               libgtest-dev
+               pkg-config
 Homepage: https://github.com/wirenboard/wb-mqtt-adc
 
 Package: wb-mqtt-adc

--- a/debian/rules
+++ b/debian/rules
@@ -1,4 +1,18 @@
 #!/usr/bin/make -f
+
+COV_FAIL_UNDER := $(patsubst cov-fail-under=%,%,$(filter cov-fail-under=%,$(DEB_BUILD_OPTIONS)))
+COV_REPORT     := $(patsubst cov-report=%,%,$(filter cov-report=%,$(DEB_BUILD_OPTIONS)))
+
+ifneq ($(COV_FAIL_UNDER),)
+	MAKEFLAGS += COV_FAIL_UNDER=$(COV_FAIL_UNDER)
+endif
+ifneq ($(COV_REPORT),)
+	MAKEFLAGS += COV_REPORT=$(COV_REPORT)
+endif
+ifneq (,$(findstring debug, $(DEB_BUILD_OPTIONS)))
+	MAKEFLAGS += DEBUG=1
+endif
+
 %:
 	dh $@ --parallel
 


### PR DESCRIPTION
How to use (with devcontainer):
```sh
make test DEBUG=1
open build/debug/cov.html
```
Using wbdev:
```sh
DEB_BUILD_OPTIONS="debug check cov-fail-under=70 cov-report=cov.html" ./wbdev cdeb
```

<img width="1680" alt="Näyttökuva 2024-9-30 kello 15 59 18" src="https://github.com/user-attachments/assets/b805e25b-194d-4b5f-bcf6-04d21a28a08e">
